### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ Cascadia.parseInteger(P("90:")) == 90
 
 ###Selector tests. Load data from file.
 
-selectorTests=JSON.parsefile(Pkg.dir("Cascadia", "test", "selectorTests.json"))
+selectorTests=JSON.parsefile(joinpath(dirname(@__FILE__), "selectorTests.json"))
 
 cnt = 0
 for (n, d) in enumerate(selectorTests)


### PR DESCRIPTION
This allows installing the package elsewhere.

Add testing against 0.5 to Travis - this runs the most
recent RC now, release once final tags are done

(there are minor cleanups, no need to re-tag right away)