### PR TITLE
added macro form of selector string

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package depends on the [Gumbo.jl](https://github.com/porterjamesj/Gumbo.jl)
 
 ### Usage
 
-Usage is simple. Use `Gumbo` to parse an HTML string into a document, create a `Selector` from a string, and then use `matchall` to get the nodes in the document that match the selector. The `matchall` function returns an array of elements which match the selector. If no match is found, a zero element array is returned. For unique matches, the array contains one element. Thus, check the length of the array to test whether a selector matches. 
+Usage is simple. Use `Gumbo` to parse an HTML string into a document, create a `Selector` from a string, and then use `matchall` to get the nodes in the document that match the selector. Alternatively, use `sel"<selector string>"` to do the same thing as `Selector`. The `matchall` function returns an array of elements which match the selector. If no match is found, a zero element array is returned. For unique matches, the array contains one element. Thus, check the length of the array to test whether a selector matches.
 
 ```julia
 using Cascadia
@@ -18,7 +18,12 @@ using Gumbo
 
 n=parsehtml("<p id=\"foo\"><p id=\"bar\">")
 s=Selector("#foo")
+sm = sel"#foo"
 matchall(s, n.root)
+# 1-element Array{Gumbo.HTMLNode,1}:
+#  Gumbo.HTMLElement{:p}
+
+matchall(sm, n.root)
 # 1-element Array{Gumbo.HTMLNode,1}:
 #  Gumbo.HTMLElement{:p}
 ```

--- a/src/Cascadia.jl
+++ b/src/Cascadia.jl
@@ -2,7 +2,7 @@ module Cascadia
 using Gumbo
 # package code goes here
 
-export Selector, nodeText
+export Selector, nodeText, @sel_str
 
 include("parser.jl")
 include("selector.jl")

--- a/src/selector.jl
+++ b/src/selector.jl
@@ -76,7 +76,11 @@ function Selector(sel::AbstractString) #->Selector
     return compiled
 end
 
-
+#// A macro wrapper around the Selector function, turns a string literal
+#// into a Selector object
+macro sel_str(sel::AbstractString)
+  Selector(sel)
+end
 
 # // MustCompile is like Compile, but panics instead of returning an error.
 


### PR DESCRIPTION
It seems like a selector lends itself quite well to a macro, since it is similar to a regex in its intent (even the function names using it are similar).