### PR TITLE
Retrieve :nth-child nodes by identity

### DIFF
--- a/src/selector.jl
+++ b/src/selector.jl
@@ -397,7 +397,7 @@ function nthChildSelector(a::Int, b::Int, last::Bool, ofType::Bool) #->Selector
                 continue
             end
             count += 1
-            if c == n
+            if c === n
                 i=count
                 if !last
                     break


### PR DESCRIPTION
Ensure that the `:nth-child`/`:nth-of-type` selectors find siblings
through the `Core.:(===)` operator. This is the same behaviour as
`nextSibling` and `prevSibling`.

Closes #21.

---

Passes tests locally.

I would appreciate eyeballs on this, I got the idea for this fix by noticing what `nextSibling` and `prevSibling` do:

https://github.com/Algocircle/Cascadia.jl/blob/64cbcf6cbc48895e8d651d4555343825258c9a7a/src/selector.jl#L20

As I understand it, because Gumbo.jl’s data takes the form of mutable structs using `===` is reliable *only* if nodes are not copied. I don’t know enough about the ecosystem to figure out if that makes this PR sensible.