### PR TITLE
Update Cascading.jl

### DIFF
--- a/src/Cascadia.jl
+++ b/src/Cascadia.jl
@@ -3,7 +3,7 @@ using Gumbo
 using AbstractTrees
 # package code goes here
 
-export Selector, nodeText, @sel_str
+export Selector, nodeText, @sel_str, matchFirst
 
 include("parser.jl")
 include("selector.jl")


### PR DESCRIPTION
Currently matchFirst function isn't exported and since this is a key extraction function commonly expected to be used, this function should be exported for ease of access. What do you think?